### PR TITLE
[RB-128] Update vehiclelink api endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [RB-128] Update vehiclelink endpoints
+
 ## 0.1.1
 
 - [RB-96] Fix npm badge

--- a/lib/vehiclelinkApi.js
+++ b/lib/vehiclelinkApi.js
@@ -17,24 +17,24 @@ class VehiclelinkApi {
     };
   }
 
-  fetchMakes() {
-    const url = `${this.host}/makes`;
+  fetchMakes(segmentCode) {
+    const url = `${this.host}/segments/${segmentCode}/makes`;
     return request(url, this.makeGetRequest());
   }
 
-  fetchFamilies(makeCode) {
+  fetchFamilies(segmentCode, makeCode) {
     const params = new URLSearchParams();
     params.append('make_code', makeCode);
-    const url = `${this.host}/families?${params}`;
+    const url = `${this.host}/segments/${segmentCode}/families?${params}`;
     return request(url, this.makeGetRequest());
   }
 
-  fetchVehicles(makeCode, familyCode, bodyStyleDescription) {
+  fetchVehicles(segmentCode, makeCode, familyCode, bodyStyleDescription) {
     const params = new URLSearchParams();
     params.append('make_code', makeCode);
     params.append('family_code', familyCode);
     params.append('body_style_description', bodyStyleDescription);
-    const url = `${this.host}/vehicles?${params}`;
+    const url = `${this.host}/segments/${segmentCode}/vehicles?${params}`;
     return request(url, this.makeGetRequest());
   }
 }

--- a/test/vehiclelinkApi.test.js
+++ b/test/vehiclelinkApi.test.js
@@ -30,17 +30,21 @@ describe('errorHandling', () => {
   });
 
   it('should handle errors when fetch makes', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchMakes('vehicles').catch((err) => {
-      expect(err.response.status).toEqual(422);
-      done();
-    });
+    new VehiclelinkApi(host, bearerToken)
+      .fetchMakes('vehicles')
+      .catch((err) => {
+        expect(err.response.status).toEqual(422);
+        done();
+      });
   });
 
   it('should handle errors when fetch families', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchFamilies('vehicles', 'TOYO').catch((err) => {
-      expect(err.response.status).toEqual(500);
-      done();
-    });
+    new VehiclelinkApi(host, bearerToken)
+      .fetchFamilies('vehicles', 'TOYO')
+      .catch((err) => {
+        expect(err.response.status).toEqual(500);
+        done();
+      });
   });
 
   it('should handle errors when fetch vehicles', (done) => {
@@ -66,12 +70,14 @@ describe('fetchMakes', () => {
   });
 
   it('should return a hash of makes', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchMakes('vehicles').then((makes) => {
-      expect(makes).toHaveLength(2);
-      expect(makes[0].description).toEqual('Toyota');
-      expect(makes[1].description).toEqual('Mazda');
-      done();
-    });
+    new VehiclelinkApi(host, bearerToken)
+      .fetchMakes('vehicles')
+      .then((makes) => {
+        expect(makes).toHaveLength(2);
+        expect(makes[0].description).toEqual('Toyota');
+        expect(makes[1].description).toEqual('Mazda');
+        done();
+      });
   });
 });
 

--- a/test/vehiclelinkApi.test.js
+++ b/test/vehiclelinkApi.test.js
@@ -11,16 +11,16 @@ const configHeaders = {
 describe('errorHandling', () => {
   beforeEach(() => {
     nock(host, { reqHeaders: configHeaders })
-      .get('/makes')
+      .get('/segments/vehicles/makes')
       .reply(422, { error: 'Test error' });
 
     nock(host, { reqHeaders: configHeaders })
-      .get('/families?make_code=TOYO')
+      .get('/segments/vehicles/families?make_code=TOYO')
       .reply(500, []);
 
     nock(host, { reqHeaders: configHeaders })
       .get(
-        '/vehicles?make_code=TOYO&family_code=PRADO&body_style_description=Style+1'
+        '/segments/vehicles/vehicles?make_code=TOYO&family_code=PRADO&body_style_description=Style+1'
       )
       .reply(500, []);
   });
@@ -30,14 +30,14 @@ describe('errorHandling', () => {
   });
 
   it('should handle errors when fetch makes', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchMakes().catch((err) => {
+    new VehiclelinkApi(host, bearerToken).fetchMakes('vehicles').catch((err) => {
       expect(err.response.status).toEqual(422);
       done();
     });
   });
 
   it('should handle errors when fetch families', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchFamilies('TOYO').catch((err) => {
+    new VehiclelinkApi(host, bearerToken).fetchFamilies('vehicles', 'TOYO').catch((err) => {
       expect(err.response.status).toEqual(500);
       done();
     });
@@ -45,7 +45,7 @@ describe('errorHandling', () => {
 
   it('should handle errors when fetch vehicles', (done) => {
     new VehiclelinkApi(host, bearerToken)
-      .fetchVehicles('TOYO', 'PRADO', 'Style 1')
+      .fetchVehicles('vehicles', 'TOYO', 'PRADO', 'Style 1')
       .catch((err) => {
         expect(err.response.status).toEqual(500);
         done();
@@ -61,12 +61,12 @@ describe('fetchMakes', () => {
     ];
 
     nock(host, { reqHeaders: configHeaders })
-      .get('/makes')
+      .get('/segments/vehicles/makes')
       .reply(200, makesResults);
   });
 
   it('should return a hash of makes', (done) => {
-    new VehiclelinkApi(host, bearerToken).fetchMakes().then((makes) => {
+    new VehiclelinkApi(host, bearerToken).fetchMakes('vehicles').then((makes) => {
       expect(makes).toHaveLength(2);
       expect(makes[0].description).toEqual('Toyota');
       expect(makes[1].description).toEqual('Mazda');
@@ -98,13 +98,13 @@ describe('fetchFamilies', () => {
     ];
 
     nock(host, { reqHeaders: configHeaders })
-      .get('/families?make_code=TOYO')
+      .get('/segments/vehicles/families?make_code=TOYO')
       .reply(200, familiesResults);
   });
 
   it('should return a hash of families', (done) => {
     new VehiclelinkApi(host, bearerToken)
-      .fetchFamilies('TOYO')
+      .fetchFamilies('vehicles', 'TOYO')
       .then((families) => {
         expect(families).toHaveLength(2);
         expect(families[0].description).toEqual('PRADO');
@@ -140,13 +140,13 @@ describe('fetchVehicles', () => {
     params.append('body_style_description', 'Style 1');
 
     nock(host, { reqHeaders: configHeaders })
-      .get(`/vehicles?${params}`)
+      .get(`/segments/vehicles/vehicles?${params}`)
       .reply(200, vehiclesResults);
   });
 
   it('should return a hash of families', (done) => {
     new VehiclelinkApi(host, bearerToken)
-      .fetchVehicles('TOYO', 'PRADO', 'Style 1')
+      .fetchVehicles('vehicles', 'TOYO', 'PRADO', 'Style 1')
       .then((vehicles) => {
         expect(vehicles).toHaveLength(1);
         expect(vehicles[0].length_value).toEqual('5100');


### PR DESCRIPTION
### WHY
Since Vehiclelink is using segment_code on every endpoint, we need to update URLs in all the requests correspondingly. 