### PR TITLE
[RB-211] Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.5.1
 
 - [RB-184] Add support for abort signal
 - [RB-205] Add support for unit selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.5.1
 
 - [RB-184] Add support for abort signal


### PR DESCRIPTION
### WHY
The Unreleased block was actually released as 0.5.1. We need to fix it.

### FYI
Last time when I did the release, looks like John had a 0.5.0 somewhere on the remote which prevented me push tag 0.5.0. So that's why we did 0.5.1 directly